### PR TITLE
Update and rename RYCOM.yml to RYMCU.yml

### DIFF
--- a/communities/RYMCU.yml
+++ b/communities/RYMCU.yml
@@ -1,5 +1,5 @@
 ---
-community_name: RYCOM
+community_name: RYMCU
 resource_types:
   software-artifact-repositories:
     repo_urls:


### PR DESCRIPTION
 Procedural issue, community name should be taken from organization name, not project name!