### PR TITLE
Add handset and mobile application development class，updated iOS and Android 

### DIFF
--- a/collections.yml
+++ b/collections.yml
@@ -71,6 +71,15 @@
     - digital-currency # 数字货币
     - nft # NFT非同质化通证
 
+- ident: handset-and-mobile-application-development
+  name: Handset and Mobile Application Development
+  name_cn: 手机和移动应用开发
+  items:
+    - android-component-and-projects # 安卓组件和项目
+    - ios-component-and-projects # iOS组件和项目
+    - mobile-apps # 移动APP
+    - cross-platform-mobile-app-development # 跨平台移动应用开发
+
 - ident: development-framework
   name: Development Framework
   name_cn: 开发框架

--- a/collections.yml
+++ b/collections.yml
@@ -75,10 +75,9 @@
   name: Handset and Mobile Application Development
   name_cn: 手机和移动应用开发
   items:
-    - android-component-and-projects # 安卓组件和项目
-    - ios-component-and-projects # iOS组件和项目
-    - mobile-apps # 移动APP
-    - cross-platform-mobile-app-development # 跨平台移动应用开发
+    - android-development-framework # 安卓组件和项目
+    - ios-framework # iOS组件和项目
+    - mobile-cross-platform-application-development # 移动跨平台应用开发
 
 - ident: development-framework
   name: Development Framework

--- a/collections/android-development-framework.yml
+++ b/collections/android-development-framework.yml
@@ -1,6 +1,6 @@
 ident: android-development-framework
-name: Android development framework
-name_cn: 安卓开发框架
+name: Android Development Component and Framework
+name_cn: 安卓开发组件和框架
 slug: /android-development-framework
 items:
   - https://github.com/androidx/androidx

--- a/collections/ios-framework.yml
+++ b/collections/ios-framework.yml
@@ -1,6 +1,6 @@
 ident: ios-framework
-name: iOS Framework
-name_cn: iOS 开发框架
+name: iOS development component and framework
+name_cn: iOS 开发组件和框架
 slug: /ios-framework
 items:
   - https://github.com/Alamofire/Alamofire
@@ -22,3 +22,4 @@ items:
   - https://github.com/Cocoanetics/DTCoreText
   - https://github.com/facebook/componentkit # no change in 1 years
   - https://github.com/theos/theos
+  - https://github.com/ionic-team/ionic-framework


### PR DESCRIPTION
Add handset and mobile application development class，updated iOS and Android development classes description.

Handset and Mobile application development are big enough to set a standalone tier 1 class for them. 

New descriptions include "other components" than "framework" only, better matter projects' characters included in yaml files.  