### PR TITLE
更新模板引擎

### DIFF
--- a/collections/template-engine.yml
+++ b/collections/template-engine.yml
@@ -16,3 +16,8 @@ items:
   - https://github.com/facebook/react
   - https://github.com/vuejs/vue
   - https://github.com/angular/angular
+  - https://github.com/pallets/jinja
+  - https://github.com/spullara/mustache.java
+  - https://github.com/scalate/scalate
+  - https://github.com/groue/GRMustache.swift
+  - https://github.com/HubSpot/jinjava


### PR DESCRIPTION
后续考虑从 name_cn: 软件开发库 - template-engine # 模板引擎  迁移至 name_cn: 程序开发工具- template-engine # 模板引擎