### PR TITLE
remove: postmanlabs/postman-app-support from api-mgr

### DIFF
--- a/collections/api-management.yml
+++ b/collections/api-management.yml
@@ -5,7 +5,6 @@ slug: /api-management
 items:
   - https://github.com/YMFE/yapi
   - https://github.com/swagger-api/swagger-ui
-  - https://github.com/postmanlabs/postman-app-support
   - https://github.com/Kong/insomnia
   - https://github.com/tiangolo/fastapi
   - https://github.com/TykTechnologies/tyk


### PR DESCRIPTION
postmanlabs/postman-app-support is not a software repository. It should not be in the API management category. It can be an issue collection repository which take the API management as a topic.