### PR TITLE
Update deepin-related communities information

### DIFF
--- a/communities/deepin-community.yml
+++ b/communities/deepin-community.yml
@@ -1,5 +1,5 @@
 ---
-community_name: deepin-community_ALL
+community_name: deepin-community
 community_logo_url: https://github.com/deepin-community.png
 community_org_url: https://github.com/deepin-community
 resource_types:

--- a/communities/linuxdeepin.yml
+++ b/communities/linuxdeepin.yml
@@ -87,14 +87,14 @@ resource_types:
         - https://github.com/linuxdeepin/deepin-compressor
         - https://github.com/linuxdeepin/deepin-log-viewer
         - https://github.com/linuxdeepin/dde-session-shell
+        - https://github.com/linuxdeepin/dde-tray-loader
+        - https://github.com/linuxdeepin/dde-shell
         - https://github.com/linuxdeepin/dde-clipboard
         - https://github.com/linuxdeepin/deepin-terminal
         - https://github.com/linuxdeepin/open-with-dialog
         - https://github.com/linuxdeepin/deepin-diskmanager
         - https://github.com/linuxdeepin/deepin-voice-note
         - https://github.com/linuxdeepin/deepin-camera
-        - https://github.com/linuxdeepin/deepin-wsl
-        - https://github.com/linuxdeepin/deepin-wsl-fs
         - https://github.com/linuxdeepin/deepin-ab-recovery
         - https://github.com/linuxdeepin/xorg-server
         - https://github.com/linuxdeepin/ttf-deepin-opensymbol
@@ -119,14 +119,12 @@ resource_types:
         - https://github.com/linuxdeepin/dtkdeclarative
         - https://github.com/linuxdeepin/action-cppcheck
         - https://github.com/linuxdeepin/action-organization-manager
-        - https://github.com/linuxdeepin/.github
         - https://github.com/linuxdeepin/action-sync
         - https://github.com/linuxdeepin/jenkins-bridge-client
         - https://github.com/linuxdeepin/upload-artifact
         - https://github.com/linuxdeepin/docparser
-        - https://github.com/linuxdeepin/dde-nixos
         - https://github.com/linuxdeepin/image-editor
-        - https://github.com/linuxdeepin/open-source-students
+        - https://github.com/linuxdeepin/deepin-sbom-tools
         - https://github.com/linuxdeepin/action-teams-manager
         - https://github.com/linuxdeepin/release
         - https://github.com/linuxdeepin/wiki
@@ -158,10 +156,8 @@ resource_types:
         - https://github.com/linuxdeepin/dde-app-services
         - https://github.com/linuxdeepin/deepin-tweak
         - https://github.com/linuxdeepin/dde-wloutput
-        - https://github.com/linuxdeepin/cla
         - https://github.com/linuxdeepin/contributor-assistant-github-action
         - https://github.com/linuxdeepin/unilang
-        - https://github.com/linuxdeepin/linglong-hub
         - https://github.com/linuxdeepin/action-doxygencheck
         - https://github.com/linuxdeepin/linglong-builder-demo
         - https://github.com/linuxdeepin/dtk-template
@@ -171,6 +167,7 @@ resource_types:
         - https://github.com/linuxdeepin/dtkbluetooth
         - https://github.com/linuxdeepin/dtkcrypt
         - https://github.com/linuxdeepin/dtkio
+        - https://github.com/linuxdeepin/dtkai
         - https://github.com/linuxdeepin/dtkmultimedia
         - https://github.com/linuxdeepin/dtknetworkmanager
         - https://github.com/linuxdeepin/dtkaudiomanager
@@ -187,7 +184,6 @@ resource_types:
         - https://github.com/linuxdeepin/dci-icon-theme
         - https://github.com/linuxdeepin/deepin-specifications
         - https://github.com/linuxdeepin/obs-service-tar_scm
-        - https://github.com/linuxdeepin/linglong-loader
         - https://github.com/linuxdeepin/linglong
         - https://github.com/linuxdeepin/deepin-wayland-protocols
         - https://github.com/linuxdeepin/doxygen-theme
@@ -219,6 +215,7 @@ resource_types:
         - https://github.com/linuxdeepin/utshell
         - https://github.com/linuxdeepin/deepin-autotest-framework
         - https://github.com/linuxdeepin/dde-launchpad
+        - https://github.com/linuxdeepin/dde-application-wizard
         - https://github.com/linuxdeepin/dtk6core
         - https://github.com/linuxdeepin/dtk6gui
         - https://github.com/linuxdeepin/dtk6widget
@@ -228,7 +225,11 @@ resource_types:
         - https://github.com/linuxdeepin/deepin-deepinid-plugin
         - https://github.com/linuxdeepin/deepin-deepinid-client
         - https://github.com/linuxdeepin/deepin-codeporting
+        - https://github.com/linuxdeepin/treeland-protocols
+        - https://github.com/linuxdeepin/dde-services
+        - https://github.com/linuxdeepin/deepin-dummyapps
     governance-repositories:
-        repo_urls: []
-
-    
+        repo_urls:
+        - https://github.com/linuxdeepin/.github
+        - https://github.com/linuxdeepin/cla
+        - https://github.com/linuxdeepin/open-source-students


### PR DESCRIPTION
更新 deepin （深度）相关的开源社区配置，大致变动如下：

- linuxdeepin 组织：
  - 更新仓库列表为最近状态，移除部分已归档/不再存在于 linuxdeepin 组织下的项目
  - 将个别仓库调整至治理（governance）类型的仓库分类下
- deepin-community 组织：重命名社区（组织）名称，去掉了 `_ALL` 后缀

另注：

当前 oss-compass 官网[已经存在名为 deepin-community 的社区](https://oss-compass.org/analyze/cp01lni1)，但一方面其页面所展示的结果为空，另一方面此仓库内看上去并不存在对应 deepin-community 社区的配置文件（[现有配置文件对应的是 deepin-community_ALL](https://oss-compass.org/analyze/ck7gtsur)）。此问题可能需要贵组织关注/处理。